### PR TITLE
Fix incomplete import and speed up processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+dotnet-install.sh

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ Or if you want to read the data from an XDocument:
     var myWorkouts = data.Workouts;
 
 ### Handling Large Export Files
-Version 1.1 processes large Apple Health exports (>200&nbsp;MB) more efficiently.
-The reader streams the XML directly from the zip file which reduces memory
-usage when loading big datasets.
+Version 1.2 processes large Apple Health exports faster by parsing records in
+parallel.
 
 ## Related Packages
 * [Spivey.Health](https://github.com/spiveyworks/Spivey.Health) can be used to convert Apple Health data into a normalized and more efficient data structure.

--- a/src/Spivey.AppleHealthFileReader/Spivey.AppleHealthFileReader/XmlHealthDataReader.cs
+++ b/src/Spivey.AppleHealthFileReader/Spivey.AppleHealthFileReader/XmlHealthDataReader.cs
@@ -43,38 +43,15 @@ namespace Spivey.AppleHealthFileReader
                 throw new FileNotFoundException($"{exportFileName} is missing from the .zip file");
 
             using Stream stream = entry.Open();
-            return Load(stream);
+            XDocument doc = XDocument.Load(stream, LoadOptions.None);
+            return Load(doc);
         }
 
         // Load an Apple Health export from an XML stream
         public AppleHealthData Load(Stream xmlStream)
         {
-            var data = new AppleHealthData();
-
-            using XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings { IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Parse });
-            while (reader.Read())
-            {
-                if (reader.NodeType != XmlNodeType.Element)
-                    continue;
-
-                switch (reader.Name)
-                {
-                    case "Record":
-                        if (XElement.ReadFrom(reader) is XElement recordElem)
-                            data.Records.Add(new Record(recordElem));
-                        break;
-                    case "Workout":
-                        if (XElement.ReadFrom(reader) is XElement workoutElem)
-                            data.Workouts.Add(new Workout(workoutElem));
-                        break;
-                    case "ClinicalRecord":
-                        if (XElement.ReadFrom(reader) is XElement clinicalElem)
-                            data.ClinicalRecords.Add(new ClinicalRecord(clinicalElem));
-                        break;
-                }
-            }
-
-            return data;
+            XDocument doc = XDocument.Load(xmlStream, LoadOptions.None);
+            return Load(doc);
         }
 
         // A constructor that takes an Apple Health export file XML document as a parameter
@@ -120,70 +97,31 @@ namespace Spivey.AppleHealthFileReader
         // A method that parses the record elements and returns a list of record objects
         private List<Record> ParseRecords(XElement root)
         {
-            // Create an empty list of record objects
-            List<Record> records = new List<Record>();
-
-            // Get all the record elements
-            IEnumerable<XElement> recordElements = root.Elements("Record");
-
-            // Loop through each record element
-            foreach (XElement recordElement in recordElements)
-            {
-                // Create a record object from the record element
-                Record record = new Record(recordElement);
-
-                // Add the record object to the list
-                records.Add(record);
-            }
-
-            // Return the list of record objects
-            return records;
+            return root
+                .Elements("Record")
+                .AsParallel()
+                .Select(e => new Record(e))
+                .ToList();
         }
 
         // A method that parses the workout elements and returns a list of workout objects
         private List<Workout> ParseWorkouts(XElement root)
         {
-            // Create an empty list of workout objects
-            List<Workout> workouts = new List<Workout>();
-
-            // Get all the workout elements
-            IEnumerable<XElement> workoutElements = root.Elements("Workout");
-
-            // Loop through each workout element
-            foreach (XElement workoutElement in workoutElements)
-            {
-                // Create a workout object from the workout element
-                Workout workout = new Workout(workoutElement);
-
-                // Add the workout object to the list
-                workouts.Add(workout);
-            }
-
-            // Return the list of workout objects
-            return workouts;
+            return root
+                .Elements("Workout")
+                .AsParallel()
+                .Select(e => new Workout(e))
+                .ToList();
         }
 
         // A method that parses the clinical record elements and returns a list of clinical record objects
         private List<ClinicalRecord> ParseClinicalRecords(XElement root)
         {
-            // Create an empty list of clinical record objects
-            List<ClinicalRecord> clinicalRecords = new List<ClinicalRecord>();
-
-            // Get all the clinical record elements
-            IEnumerable<XElement> clinicalRecordElements = root.Elements("ClinicalRecord");
-
-            // Loop through each clinical record element
-            foreach (XElement clinicalRecordElement in clinicalRecordElements)
-            {
-                // Create a clinical record object from the clinical record element
-                ClinicalRecord clinicalRecord = new ClinicalRecord(clinicalRecordElement);
-
-                // Add the clinical record object to the list
-                clinicalRecords.Add(clinicalRecord);
-            }
-
-            // Return the list of clinical record objects
-            return clinicalRecords;
+            return root
+                .Elements("ClinicalRecord")
+                .AsParallel()
+                .Select(e => new ClinicalRecord(e))
+                .ToList();
         }
     }
 }

--- a/src/Spivey.AppleHealthFileReader/Spivey.AppleHealthFileReader/XmlHealthDataReader.cs
+++ b/src/Spivey.AppleHealthFileReader/Spivey.AppleHealthFileReader/XmlHealthDataReader.cs
@@ -85,10 +85,10 @@ namespace Spivey.AppleHealthFileReader
             ZipFile.ExtractToDirectory(zipPath, tempFolder);
 
             // Get the path of the XML file
-            string xmlPath = Directory.GetFiles(tempFolder, exportFileName, SearchOption.AllDirectories).FirstOrDefault();
-
-            if (xmlPath == null)
-                throw new FileNotFoundException($"{exportFileName} is missing from the .zip file");
+            string xmlPath = Directory
+                .GetFiles(tempFolder, exportFileName, SearchOption.AllDirectories)
+                .FirstOrDefault()
+                ?? throw new FileNotFoundException($"{exportFileName} is missing from the .zip file");
 
             // Return the path of the XML file
             return xmlPath;
@@ -100,6 +100,7 @@ namespace Spivey.AppleHealthFileReader
             return root
                 .Elements("Record")
                 .AsParallel()
+                .WithDegreeOfParallelism(Environment.ProcessorCount)
                 .Select(e => new Record(e))
                 .ToList();
         }
@@ -110,6 +111,7 @@ namespace Spivey.AppleHealthFileReader
             return root
                 .Elements("Workout")
                 .AsParallel()
+                .WithDegreeOfParallelism(Environment.ProcessorCount)
                 .Select(e => new Workout(e))
                 .ToList();
         }
@@ -120,6 +122,7 @@ namespace Spivey.AppleHealthFileReader
             return root
                 .Elements("ClinicalRecord")
                 .AsParallel()
+                .WithDegreeOfParallelism(Environment.ProcessorCount)
                 .Select(e => new ClinicalRecord(e))
                 .ToList();
         }


### PR DESCRIPTION
## Summary
- ensure zip data is fully parsed by loading to `XDocument`
- parse records, workouts, and clinical records in parallel for better performance
- document the faster parallel parsing in README
- ignore `dotnet-install.sh`

## Testing
- `dotnet build src/Spivey.AppleHealthFileReader/Spivey.AppleHealthFileReader/Spivey.AppleHealthFileReader.csproj -warnaserror` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861fb5b563c8327a95e2d27326d7b5b